### PR TITLE
fix: remove orphan bytes causing hidden Unicode character warnings

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words-list = requestor

--- a/README.md
+++ b/README.md
@@ -130,14 +130,14 @@ $ sudo tree /etc/kubernetes/pki
 ├── ca.crt
 ├── ca.key
 ├── etcd
-│   ├── ca.crt
-│   ├── ca.key
-│   ├── healthcheck-client.crt
-│   ├── healthcheck-client.key
-│   ├── peer.crt
-│   ├── peer.key
-│   ├── server.crt
-│   └── server.key
+│   ├── ca.crt
+│   ├── ca.key
+│   ├── healthcheck-client.crt
+│   ├── healthcheck-client.key
+│   ├── peer.crt
+│   ├── peer.key
+│   ├── server.crt
+│   └── server.key
 ├── front-proxy-ca.crt
 ├── front-proxy-ca.key
 ├── front-proxy-client.crt


### PR DESCRIPTION
Remove 16 orphan `0xC2` bytes from the directory tree listing in `README.md`. These were remnants of corrupted `U+00A0` (non-breaking space) sequences that made the file invalid UTF-8 and triggered Renovate warnings about hidden Unicode characters.

Also adds `.codespellrc` to ignore `requestor` false positive from `kubectl` output.

Resolves Renovate warning:
> WARN: Hidden Unicode characters have been discovered in file(s) in your repository.